### PR TITLE
DWX-17395: Fix the timeout issue in reduced mode environment deletion

### DIFF
--- a/aws-iam-policies/reduced-permissions-mode.json
+++ b/aws-iam-policies/reduced-permissions-mode.json
@@ -14,7 +14,6 @@
                 "autoscaling:SuspendProcesses",
                 "autoscaling:UpdateAutoScalingGroup",
                 "cloudformation:DescribeStackEvents",
-                "cloudformation:DescribeStacks",
                 "cloudformation:UpdateStack",
                 "ec2:DeleteKeyPair"
             ],
@@ -82,6 +81,12 @@
                     "aws:CalledVia": "cloudformation.amazonaws.com"
                 }
             }
+        },
+        {
+            "Sid": "gocodeCF",
+            "Effect": "Allow",
+            "Action": "cloudformation:DescribeStacks",
+            "Resource": "arn:aws:cloudformation:*:*:stack/env-*-dwx-stack/*"
         },
         {
             "Sid": "gocodeEks",


### PR DESCRIPTION
The restriction on cloudformation:DescribeStacks is changed in reduced mode policy from tag based to resource based as it is in restricted policy. this is done to remove a bug that caused 403 errors on describe stacks calls made by dwx server and led to timeouts while deleting the stack

---
# Pull Request checklist:

### Description:
- [ ] Description of the change is added
- [ ] Jira ID is added to the title

**Changes to any files in generated folder(not to be touched)**
- [ ] No
- [ ] Yes

**Is the DWX JIRA PR using a new AWS SDK API which needs new permission(s), not included in either of the files under
https://github.com/cloudera/cdw-cloud-policies/tree/main/aws-iam-policies/docs then create a PR to include the new action**

- [ ] Include in [Reduced mode cross account Policy](./aws-iam-policies/reduced-permissions-mode.json)
- [ ] Include in [Restricted cross account Policy](./aws-iam-policies/docs)

**Is the dwx-cf-template.yaml being modified, that is specifically any new resources are added or if new permissions/actions are needed.**

- [ ] Include in [Restricted cross account Policy](./aws-iam-policies/docs)

**Are new permissions added in the policies section of "NodeInstanceRole" section of dwx-cf-template.yaml**

- [ ] Include in [Managed Policy Inline Node Role Policy](./aws-iam-policies/managedArn-node-inline-policy.json)

**Is this a bug fix for an old release, with missing permission, example [DWX-15473](https://jira.cloudera.com/browse/DWX-15473)**

- [ ] Create a TSB about the missing permission


**Backward compatibility**

- [ ] No breaking changes for upgrades
- [ ] Yes, then create a TSB, 

### Testing:
  - [ ] Manual tests (**add details**)
  - [ ] Control Plane integrated
  - [ ] mow-priv
