### PR TITLE
DWX-17623 Update managed ARN policy to support cluster autoscaler to …

### DIFF
--- a/aws-iam-policies/managedArn-node-inline-policy.json
+++ b/aws-iam-policies/managedArn-node-inline-policy.json
@@ -9,6 +9,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeTags",
         "autoscaling:DescribeLaunchConfigurations",
+        "autoscaling:DescribeScalingActivities",
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "ec2:DescribeLaunchTemplateVersions",


### PR DESCRIPTION
…1.28

As part of upgrade cluster autoscaler to 1.28, the node instance role policy is updated in the CF template. Keeping it in sync for managed policy ARN feature.
---
# Pull Request checklist:

### Description:
- [x] Description of the change is added
- [x] Jira ID is added to the title

**Changes to any files in generated folder(not to be touched)**
- [ x] No
- [ ] Yes

**Is the DWX JIRA PR using a new AWS SDK API which needs new permission(s), not included in either of the files under
https://github.com/cloudera/cdw-cloud-policies/tree/main/aws-iam-policies/docs then create a PR to include the new action**

- [ ] Include in [Reduced mode cross account Policy](./aws-iam-policies/reduced-permissions-mode.json)
- [ ] Include in [Restricted cross account Policy](./aws-iam-policies/docs)

**Is the dwx-cf-template.yaml being modified, that is specifically any new resources are added or if new permissions/actions are needed.**

- [ ] Include in [Restricted cross account Policy](./aws-iam-policies/docs)

**Are new permissions added in the policies section of "NodeInstanceRole" section of dwx-cf-template.yaml**

- [x] Include in [Managed Policy Inline Node Role Policy](./aws-iam-policies/managedArn-node-inline-policy.json)

**Is this a bug fix for an old release, with missing permission, example [DWX-15473](https://jira.cloudera.com/browse/DWX-15473)**

- [ ] Create a TSB about the missing permission


**Backward compatibility**

- [x] No breaking changes for upgrades
- [ ] Yes, then create a TSB, 

### Testing:
  - [ ] Manual tests (**add details**)
  - [ ] Control Plane integrated
  - [ ] mow-priv
