### PR TITLE
DWX-17929: Add permissions for Start Stop Cluster feature

### DIFF
--- a/aws-iam-policies/docs/restricted-policy-doc-1.json5
+++ b/aws-iam-policies/docs/restricted-policy-doc-1.json5
@@ -293,6 +293,23 @@
         // Upgrade needs old/new instance status
       ],
       "Resource": "*"
-    }
+    },
+    {
+            "Sid": "StartStopRDS",
+            "Effect": "Allow",
+            "Action": [
+                "rds:StartDBInstance",
+                // Stop RDS Instance while stopping the cluster
+                "rds:StopDBInstance",
+                // Start RDS Instance while starting the cluster
+                "rds:DescribeDBInstances"
+                // Describe RDBS (postgres) instance created by
+                // cf, used to detect quota of DB instance
+            ],
+            "Resource": [
+                "arn:aws:rds:*:*:db:env-*-dwx-stack-rds",
+                "arn:aws:rds:*:*:subgrp:env-*-dwx-stack-dbsubnetgroup-*"
+            ]
+        }
   ]
 }

--- a/aws-iam-policies/docs/restricted-policy-doc-1.json5
+++ b/aws-iam-policies/docs/restricted-policy-doc-1.json5
@@ -295,21 +295,21 @@
       "Resource": "*"
     },
     {
-            "Sid": "StartStopRDS",
-            "Effect": "Allow",
-            "Action": [
-                "rds:StartDBInstance",
-                // Stop RDS Instance while stopping the cluster
-                "rds:StopDBInstance",
-                // Start RDS Instance while starting the cluster
-                "rds:DescribeDBInstances"
-                // Describe RDBS (postgres) instance created by
-                // cf, used to detect quota of DB instance
-            ],
-            "Resource": [
-                "arn:aws:rds:*:*:db:env-*-dwx-stack-rds",
-                "arn:aws:rds:*:*:subgrp:env-*-dwx-stack-dbsubnetgroup-*"
-            ]
-        }
+      "Sid": "StartStopRDS",
+      "Effect": "Allow",
+      "Action": [
+        "rds:StartDBInstance",
+        // Stop RDS Instance while stopping the cluster
+        "rds:StopDBInstance",
+        // Start RDS Instance while starting the cluster
+        "rds:DescribeDBInstances"
+        // Describe RDBS (postgres) instance created by
+        // cf, used to detect quota of DB instance
+      ],
+      "Resource": [
+        "arn:aws:rds:*:*:db:env-*-dwx-stack-rds",
+        "arn:aws:rds:*:*:subgrp:env-*-dwx-stack-dbsubnetgroup-*"
+      ]
+    }
   ]
 }

--- a/aws-iam-policies/docs/restricted-policy-doc-2.json5
+++ b/aws-iam-policies/docs/restricted-policy-doc-2.json5
@@ -129,10 +129,7 @@
       "Action": [
         "rds:CreateDBInstance",
         // The RDBS (postgres) created to store dwx
-        // cluster info during activation
-        "rds:DescribeDBInstances",
-        // Describe RDBS (postgres) instance created by
-        // cf, used to detect quota of DB instance
+        // cluster info during activation        
         "rds:CreateDBSubnetGroup",
         // The DBSubnetGroup created during activation
         "rds:DescribeDBSubnetGroups",

--- a/aws-iam-policies/reduced-permissions-mode.json
+++ b/aws-iam-policies/reduced-permissions-mode.json
@@ -148,6 +148,19 @@
                 "s3:PutObjectAcl"
             ],
             "Resource": "*"
+        },
+        {
+            "Sid": "StartStopRDS",
+            "Effect": "Allow",
+            "Action": [
+                "rds:StartDBInstance",
+                "rds:StopDBInstance",
+                "rds:DescribeDBInstances"
+            ],
+            "Resource": [
+                "arn:aws:rds:*:*:db:env-*-dwx-stack-rds",
+                "arn:aws:rds:*:*:subgrp:env-*-dwx-stack-dbsubnetgroup-*"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Permissions needed for starting and stopping RDS as part of DWX-17929

---
# Pull Request checklist:

### Description:
- [x] Description of the change is added
- [ ] Jira ID is added to the title

**Changes to any files in generated folder(not to be touched)**
- [x] No
- [ ] Yes

**Is the DWX JIRA PR using a new AWS SDK API which needs new permission(s), not included in either of the files under
https://github.com/cloudera/cdw-cloud-policies/tree/main/aws-iam-policies/docs then create a PR to include the new action**

- [ ] Include in [Reduced mode cross account Policy](./aws-iam-policies/reduced-permissions-mode.json)
- [x] Include in [Restricted cross account Policy](./aws-iam-policies/docs)

**Is the dwx-cf-template.yaml being modified, that is specifically any new resources are added or if new permissions/actions are needed.**

- [x] Include in [Restricted cross account Policy](./aws-iam-policies/docs)

**Are new permissions added in the policies section of "NodeInstanceRole" section of dwx-cf-template.yaml**

- [ ] Include in [Managed Policy Inline Node Role Policy](./aws-iam-policies/managedArn-node-inline-policy.json)

**Is this a bug fix for an old release, with missing permission, example [DWX-15473](https://jira.cloudera.com/browse/DWX-15473)**

- [ ] Create a TSB about the missing permission


**Backward compatibility**

- [x] No breaking changes for upgrades
- [ ] Yes, then create a TSB, 

### Testing:
  - [ ] Manual tests (**add details**)
  - [x] Control Plane integrated
  - [ ] mow-priv
