### PR TITLE
DWX-17678: Add iam:TagRole to restricted mode

### DIFF
--- a/aws-iam-policies/docs/restricted-policy-doc-2.json5
+++ b/aws-iam-policies/docs/restricted-policy-doc-2.json5
@@ -251,6 +251,20 @@
           "aws:CalledVia": "cloudformation.amazonaws.com"
         }
       }
+    },
+    {
+      "Sid": "TagRoleRestriction",
+      "Effect": "Allow",
+      "Action": [
+        // used by Cloudformation to tag EKSServiceRole and NodeInstanceRole
+        "iam:TagRole"
+      ],
+      "Resource": "*",
+      "Condition": {
+          "ForAnyValue:StringEquals": {
+            "aws:CalledVia": "cloudformation.amazonaws.com"
+          }
+      }
     }
   ]
 }


### PR DESCRIPTION
iam:TagRole permission is required for CF to tag EKSServiceRole and NodeInstanceRole with whatever tags were passed to CF itself. This is not needed in reduced permissions mode since activation of CF is done by user with complete access. 

---
# Pull Request checklist:

### Description:
- [x] Description of the change is added
- [x] Jira ID is added to the title

**Changes to any files in generated folder(not to be touched)**
- [x] No
- [ ] Yes

**Is the DWX JIRA PR using a new AWS SDK API which needs new permission(s), not included in either of the files under
https://github.com/cloudera/cdw-cloud-policies/tree/main/aws-iam-policies/docs then create a PR to include the new action**

- [ ] Include in [Reduced mode cross account Policy](./aws-iam-policies/reduced-permissions-mode.json)
- [x] Include in [Restricted cross account Policy](./aws-iam-policies/docs)

**Is the dwx-cf-template.yaml being modified, that is specifically any new resources are added or if new permissions/actions are needed.**

- [ ] Include in [Restricted cross account Policy](./aws-iam-policies/docs)

**Are new permissions added in the policies section of "NodeInstanceRole" section of dwx-cf-template.yaml**

- [ ] Include in [Managed Policy Inline Node Role Policy](./aws-iam-policies/managedArn-node-inline-policy.json)

**Is this a bug fix for an old release, with missing permission, example [DWX-15473](https://jira.cloudera.com/browse/DWX-15473)**

- [ ] Create a TSB about the missing permission


**Backward compatibility**

- [x] No breaking changes for upgrades
- [ ] Yes, then create a TSB, 

### Testing:
  - [ ] Manual tests (**add details**)
  - [ ] Control Plane integrated
  - [x] mow-dev
