### PR TITLE
DWX-19188: Add permission to remove dynamodb table

### DIFF
--- a/aws-iam-policies/docs/restricted-policy-doc-1.json5
+++ b/aws-iam-policies/docs/restricted-policy-doc-1.json5
@@ -202,9 +202,11 @@
         // Create ssh Public key pair, pass to ec2
         // instances. Not required if passed/set/
         // reused via CB
-        "ec2:DescribeInstanceTypes"
+        "ec2:DescribeInstanceTypes",
         // validate whether instance type is supported in a
         // region or not
+        "dynamodb:DeleteTable"
+        // delete dynamo db tables
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
deletion of cluster was failing in restricted policy environment due to this error - 

failed to delete dynamoDB table qe-s3-bucket-weekly: AccessDeniedException: User: arn:aws:sts::123014800043:assumed-role/dwx-qe-restricted-policy-perms/1724771564696996121 is not authorized to perform: dynamodb:DeleteTable on resource: arn:aws:dynamodb:us-west-2:123014800043:table/qe-s3-bucket-weekly because no identity-based policy allows the dynamodb:DeleteTable action

---
# Pull Request checklist:

### Description:
- [x] Description of the change is added
- [x] Jira ID is added to the title

**Changes to any files in generated folder(not to be touched)**
- [x] No
- [ ] Yes

**Is the DWX JIRA PR using a new AWS SDK API which needs new permission(s), not included in either of the files under
https://github.com/cloudera/cdw-cloud-policies/tree/main/aws-iam-policies/docs then create a PR to include the new action**

- [ ] Include in [Reduced mode cross account Policy](./aws-iam-policies/reduced-permissions-mode.json)
- [x] Include in [Restricted cross account Policy](./aws-iam-policies/docs)

**Is the dwx-cf-template.yaml being modified, that is specifically any new resources are added or if new permissions/actions are needed.**

- [ ] Include in [Restricted cross account Policy](./aws-iam-policies/docs)

**Are new permissions added in the policies section of "NodeInstanceRole" section of dwx-cf-template.yaml**

- [ ] Include in [Managed Policy Inline Node Role Policy](./aws-iam-policies/managedArn-node-inline-policy.json)

**Is this a bug fix for an old release, with missing permission, example [DWX-15473](https://jira.cloudera.com/browse/DWX-15473)**

- [ ] Create a TSB about the missing permission


**Backward compatibility**

- [x] No breaking changes for upgrades
- [ ] Yes, then create a TSB, 

### Testing:
  - [x] Manual tests - mow-dev env created and deleted. 
  - [ ] Control Plane integrated
  - [ ] mow-priv
