### PR TITLE
DWX-19903: Add missing RDS IAM permission to list DB Parameter Groups

### DIFF
--- a/aws-iam-policies/docs/restricted-policy-doc-2.json5
+++ b/aws-iam-policies/docs/restricted-policy-doc-2.json5
@@ -143,8 +143,10 @@
         // Required by Cloudformation to create RDS Parameter Group
         "rds:DeleteDBParameterGroup",
         // Required by Cloudformation to delete RDS Parameter Group
-        "rds:ModifyDBParameterGroup"
+        "rds:ModifyDBParameterGroup",
         // Required by Cloudformation to modify RDS Parameter Group
+        "rds:DescribeDBParameterGroups"
+        // Required by Cloudformation to describe RDS Parameter Group
 
       ],
       "Condition": {


### PR DESCRIPTION
PR #16 added permissions to work with RDS DB Parameter Groups but missed a necessary permission `rds:DescribeDBParameterGroups`.
---
# Pull Request checklist:

### Description:
- [X] Description of the change is added
- [X] Jira ID is added to the title

**Changes to any files in generated folder(not to be touched)**
- [X] No
- [ ] Yes

**Is the DWX JIRA PR using a new AWS SDK API which needs new permission(s), not included in either of the files under
https://github.com/cloudera/cdw-cloud-policies/tree/main/aws-iam-policies/docs then create a PR to include the new action**

- [ ] Include in [Reduced mode cross account Policy](./aws-iam-policies/reduced-permissions-mode.json)
- [X] Include in [Restricted cross account Policy](./aws-iam-policies/docs)

**Is the dwx-cf-template.yaml being modified, that is specifically any new resources are added or if new permissions/actions are needed.**

- [ ] Include in [Restricted cross account Policy](./aws-iam-policies/docs)

**Are new permissions added in the policies section of "NodeInstanceRole" section of dwx-cf-template.yaml**

- [ ] Include in [Managed Policy Inline Node Role Policy](./aws-iam-policies/managedArn-node-inline-policy.json)

**Is this a bug fix for an old release, with missing permission, example [DWX-15473](https://jira.cloudera.com/browse/DWX-15473)**

- [ ] Create a TSB about the missing permission


**Backward compatibility**

- [X] No breaking changes for upgrades
- [ ] Yes, then create a TSB, 

### Testing:
  - [X] Manual tests (**add details**)
          Created IAM policy via AWS console and saw the missing permission was available.
  - [ ] Control Plane integrated
  - [ ] mow-priv
