### PR TITLE
DWX-19990: Add Log Bucket and its Access for Managed ARN Restricted Policies

### DIFF
--- a/aws-iam-policies/docs/restricted-policy-doc-1.json5
+++ b/aws-iam-policies/docs/restricted-policy-doc-1.json5
@@ -262,7 +262,7 @@
       "Resource": [
         "arn:aws:s3:::${DATALAKE_BUCKET}/cf-templates/*",
         "arn:aws:s3:::${DATALAKE_BUCKET}/backup/*",
-        "arn:aws:s3:::${LOG_BUCKET}/*"
+        "arn:aws:s3:::${LOG_BUCKET}/cdw/*"
         // Add the above bucket if you are using a separate log bucket
       ]
     },

--- a/aws-iam-policies/docs/restricted-policy-doc-1.json5
+++ b/aws-iam-policies/docs/restricted-policy-doc-1.json5
@@ -253,13 +253,17 @@
       "Action": [
         "s3:PutObject",
         // Put cf template in SDX bucket
+        // Operations on Log Bucket
         "s3:GetObject"
         // Get cf template while cf stack creation may
         // not be needed for reduced mode
+        // Operations on Log Bucket
       ],
       "Resource": [
         "arn:aws:s3:::${DATALAKE_BUCKET}/cf-templates/*",
-        "arn:aws:s3:::${DATALAKE_BUCKET}/backup/*"
+        "arn:aws:s3:::${DATALAKE_BUCKET}/backup/*",
+        "arn:aws:s3:::${LOG_BUCKET}/*"
+        // Add the above bucket if you are using a separate log bucket
       ]
     },
     {

--- a/aws-iam-policies/reduced-permissions-mode.json
+++ b/aws-iam-policies/reduced-permissions-mode.json
@@ -122,7 +122,7 @@
             "Resource": [
                 "arn:aws:s3:::${DATALAKE_BUCKET}/cf-templates/*",
                 "arn:aws:s3:::${DATALAKE_BUCKET}/backup/*",
-                "arn:aws:s3:::${LOG_BUCKET}/*"
+                "arn:aws:s3:::${LOG_BUCKET}/cdw/*"
             ]
         },
         {

--- a/aws-iam-policies/reduced-permissions-mode.json
+++ b/aws-iam-policies/reduced-permissions-mode.json
@@ -121,7 +121,8 @@
             ],
             "Resource": [
                 "arn:aws:s3:::${DATALAKE_BUCKET}/cf-templates/*",
-                "arn:aws:s3:::${DATALAKE_BUCKET}/backup/*"
+                "arn:aws:s3:::${DATALAKE_BUCKET}/backup/*",
+                "arn:aws:s3:::${LOG_BUCKET}/*"
             ]
         },
         {


### PR DESCRIPTION
Based on QE test changes, we got S3 Access denied when a different log bucket was used. This is because we only specify permissions to work on the DL bucket. To mitigate this issue, we can add another bucket for Logs in the Sid: S3PutGetObject. 

---
# Pull Request checklist:

### Description:
- [x] Description of the change is added
- [x] Jira ID is added to the title

**Changes to any files in generated folder(not to be touched)**
- [x] No
- [ ] Yes

**Is the DWX JIRA PR using a new AWS SDK API which needs new permission(s), not included in either of the files under
https://github.com/cloudera/cdw-cloud-policies/tree/main/aws-iam-policies/docs then create a PR to include the new action**

- [ ] Include in [Reduced mode cross account Policy](./aws-iam-policies/reduced-permissions-mode.json)
- [ ] Include in [Restricted cross account Policy](./aws-iam-policies/docs)

**Is the dwx-cf-template.yaml being modified, that is specifically any new resources are added or if new permissions/actions are needed.**

- [ ] Include in [Restricted cross account Policy](./aws-iam-policies/docs)

**Are new permissions added in the policies section of "NodeInstanceRole" section of dwx-cf-template.yaml**

- [ ] Include in [Managed Policy Inline Node Role Policy](./aws-iam-policies/managedArn-node-inline-policy.json)

**Is this a bug fix for an old release, with missing permission, example [DWX-15473](https://jira.cloudera.com/browse/DWX-15473)**

- [ ] Create a TSB about the missing permission


**Backward compatibility**

- [x] No breaking changes for upgrades
- [ ] Yes, then create a TSB, 

### Testing:
  - [x] Manual tests - QE team
  - [ ] Control Plane integrated
  - [ ] mow-priv
