### PR TITLE
DWX-20218: add rds:DescribeDBParameterGroups permission to CFRDS Sid

### DIFF
--- a/aws-iam-policies/docs/restricted-policy-doc-2.json5
+++ b/aws-iam-policies/docs/restricted-policy-doc-2.json5
@@ -143,9 +143,10 @@
         // Required by Cloudformation to create RDS Parameter Group
         "rds:DeleteDBParameterGroup",
         // Required by Cloudformation to delete RDS Parameter Group
-        "rds:ModifyDBParameterGroup"
+        "rds:ModifyDBParameterGroup",
         // Required by Cloudformation to modify RDS Parameter Group
-
+        "rds:DescribeDBParameterGroups"
+        // Required by Cloudformation while creating RDS Parameter Group
       ],
       "Condition": {
         "ForAnyValue:StringEquals": {


### PR DESCRIPTION
As per findings from DWX-20218 we are seeing an error while creating DWX stack - 
Resource handler returned message: "User: arn:aws:sts::123014800043:assumed-role/dwx-qe-restricted-policy-perms/1739358553867968483 is not authorized to perform: rds:DescribeDBParameterGroups on resource: arn:aws:rds:us-west-2:123014800043:pg:env-lbm6m8-dwx-stack-rds-parameter-group because no identity-based policy allows the rds:DescribeDBParameterGroups action (Service: Rds, Status Code: 403, Request ID: 2c5c6d51-7905-4840-b1d7-bb2ab63aa061)" (RequestToken: 6728251e-7136-c269-b175-5df8c2473133, HandlerErrorCode: GeneralServiceException) 

This PR tries to resolve this bug


---
# Pull Request checklist:

### Description:
- [x] Description of the change is added
- [x] Jira ID is added to the title

**Changes to any files in generated folder(not to be touched)**
- [x] No
- [ ] Yes

**Is the DWX JIRA PR using a new AWS SDK API which needs new permission(s), not included in either of the files under
https://github.com/cloudera/cdw-cloud-policies/tree/main/aws-iam-policies/docs then create a PR to include the new action**

- [ ] Include in [Reduced mode cross account Policy](./aws-iam-policies/reduced-permissions-mode.json)
- [ ] Include in [Restricted cross account Policy](./aws-iam-policies/docs)

**Is the dwx-cf-template.yaml being modified, that is specifically any new resources are added or if new permissions/actions are needed.**

- [ ] Include in [Restricted cross account Policy](./aws-iam-policies/docs)

**Are new permissions added in the policies section of "NodeInstanceRole" section of dwx-cf-template.yaml**

- [ ] Include in [Managed Policy Inline Node Role Policy](./aws-iam-policies/managedArn-node-inline-policy.json)

**Is this a bug fix for an old release, with missing permission, example [DWX-15473](https://jira.cloudera.com/browse/DWX-15473)**

- [ ] Create a TSB about the missing permission


**Backward compatibility**

- [x] No breaking changes for upgrades
- [ ] Yes, then create a TSB, 

### Testing:
  - [x] Manual tests - mowdev
  - [ ] Control Plane integrated
  - [ ] mow-priv
